### PR TITLE
fix(plugin): fix local names in resolver plugin

### DIFF
--- a/src/babel/import-resolver-plugin.js
+++ b/src/babel/import-resolver-plugin.js
@@ -14,7 +14,7 @@ const createDestructedDeclaration = (t, specifier, source) =>
       t.objectPattern([
         t.objectProperty(
           t.identifier(specifier.imported.name),
-          t.identifier(specifier.imported.name),
+          t.identifier(specifier.local.name),
           false,
           true,
         ),

--- a/src/babel/import-resolver-plugin.spec.js
+++ b/src/babel/import-resolver-plugin.spec.js
@@ -32,6 +32,13 @@ const {
   Component
 } = ${resolverId}("react");`,
   },
+  {
+    name: "as",
+    source: "import { Component as C } from 'react'",
+    expected: `const {
+  Component: C
+} = ${resolverId}("react");`,
+  },
 ]
 
 Babel.registerPlugin("import-resolver", importResolverPlugin)


### PR DESCRIPTION
Fix work with different local names, i.e:
```js
import { Component as C } from 'react'
```