### PR TITLE
feat(SourceRender): add `renderHtml` prop

### DIFF
--- a/docs/components/Props.js
+++ b/docs/components/Props.js
@@ -60,6 +60,12 @@ const Usage = () => (
           </Table.Row>
           <Table.Row>
             <Table.Cell>
+              <code>renderHtml</code>
+            </Table.Cell>
+            <Table.Cell>An options that controls rendering of HTML with ReactDOM server, it allows to omit rendering when you're using portals.</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
               <code>resolver</code>
             </Table.Cell>
             <Table.Cell>A function for the imports resolution.</Table.Cell>

--- a/docs/components/Props.js
+++ b/docs/components/Props.js
@@ -62,7 +62,10 @@ const Usage = () => (
             <Table.Cell>
               <code>renderHtml</code>
             </Table.Cell>
-            <Table.Cell>An options that controls rendering of HTML with ReactDOM server, it allows to omit rendering when you're using portals.</Table.Cell>
+            <Table.Cell>
+              An option that controls rendering of HTML with ReactDOM server, it allows to omit
+              rendering when you are using portals.
+            </Table.Cell>
           </Table.Row>
           <Table.Row>
             <Table.Cell>

--- a/docs/components/Sandbox/Sandbox.js
+++ b/docs/components/Sandbox/Sandbox.js
@@ -103,6 +103,7 @@ export default Example
             color="black"
             href="https://github.com/layershifter/react-source-render/blob/master/docs/components/Sandbox"
             size="tiny"
+            style={{ zIndex: 10 }}
             target="blank"
           >
             <Icon name="github" /> View source

--- a/package.json
+++ b/package.json
@@ -92,8 +92,10 @@
     ]
   },
   "husky": {
-    "pre-commit": "lint-staged",
-    "post-commit": "git update-index --again"
+    "hooks": {
+      "pre-commit": "lint-staged",
+      "post-commit": "git update-index --again"
+    }
   },
   "lint-staged": {
     ".babelrc": [

--- a/package.json
+++ b/package.json
@@ -67,8 +67,6 @@
   "scripts": {
     "build:docs": "cross-env NODE_ENV=production react-static build",
     "build:lib": "node rollup.js",
-    "precommit": "lint-staged",
-    "postcommit": "git update-index --again",
     "deploy": "gh-pages -d dist",
     "lint": "eslint .",
     "prerelease": "yarn lint && yarn test && yarn build:lib",
@@ -92,6 +90,10 @@
     "setupFiles": [
       "<rootDir>/setupTests.js"
     ]
+  },
+  "husky": {
+    "pre-commit": "lint-staged",
+    "post-commit": "git update-index --again"
   },
   "lint-staged": {
     ".babelrc": [

--- a/src/SourceRender.js
+++ b/src/SourceRender.js
@@ -29,6 +29,12 @@ export default class SourceRender extends Component {
     onSuccess: PropTypes.func,
 
     /**
+     * An option that controls rendering of HTML with ReactDOM server, it allows to omit
+     * rendering when you're using portals.
+     */
+    renderHtml: PropTypes.bool,
+
+    /**
      * A function for the imports resolution.
      *
      * @param {String} importPath
@@ -43,6 +49,7 @@ export default class SourceRender extends Component {
     babelConfig: {},
     onError: noop,
     onSuccess: noop,
+    renderHtml: true,
   }
 
   state = {
@@ -72,14 +79,14 @@ export default class SourceRender extends Component {
 
   renderElement() {
     this.frameId = requestAnimationFrame(() => {
-      const { babelConfig, onError, onSuccess, resolver, source, ...rest } = this.props
+      const { babelConfig, onError, onSuccess, renderHtml, resolver, source, ...rest } = this.props
       const { element: prevElement } = this.state
 
       unmountComponentAtNode(this.ref)
 
       try {
         const element = createElementFromSource(babelConfig, resolver, rest, source)
-        const markup = renderToStaticMarkup(element)
+        const markup = renderHtml ? renderToStaticMarkup(element) : null
 
         render(element, this.ref)
         onSuccess(null, { ...this.props, element, markup })

--- a/src/SourceRender.spec.js
+++ b/src/SourceRender.spec.js
@@ -117,7 +117,14 @@ describe("SourceRender", () => {
   describe("renderHtml", () => {
     it("will be called with null markup when is `false`", () => {
       const onSuccess = jest.fn()
-      mount(<SourceRender onSuccess={onSuccess} source={validSource} renderHtml={false} resolver={reactResolver} />)
+      mount(
+        <SourceRender
+          onSuccess={onSuccess}
+          source={validSource}
+          renderHtml={false}
+          resolver={reactResolver}
+        />,
+      )
 
       jest.runAllTimers()
       expect(onSuccess).toBeCalledWith(

--- a/src/SourceRender.spec.js
+++ b/src/SourceRender.spec.js
@@ -113,4 +113,19 @@ describe("SourceRender", () => {
       )
     })
   })
+
+  describe("renderHtml", () => {
+    it("will be called with null markup when is `false`", () => {
+      const onSuccess = jest.fn()
+      mount(<SourceRender onSuccess={onSuccess} source={validSource} renderHtml={false} resolver={reactResolver} />)
+
+      jest.runAllTimers()
+      expect(onSuccess).toBeCalledWith(
+        null,
+        expect.objectContaining({
+          markup: null,
+        }),
+      )
+    })
+  })
 })


### PR DESCRIPTION
Refs https://github.com/Semantic-Org/Semantic-UI-React/pull/3029

This PR adds the new ``renderHtml` prop:
> An options that controls rendering of HTML with ReactDOM server, it allows to omit rendering when you're using portals.

It's very usefull because we can't render HTML markup with ReactDOM server:
> Portals are not currently supported by the server renderer. Render them conditionally so that they only appear on the client render.

